### PR TITLE
fix(digimon.js): change filter method to find method to return a single digimon object instead of an array

### DIFF
--- a/routes/api/digimon.js
+++ b/routes/api/digimon.js
@@ -19,7 +19,7 @@ router.get('/name/:name', (req, res) => {
     const found = digimon.some(digimon => digimon.name.toLowerCase() === digimon_name.toLowerCase());
     
     if(found) {
-        res.json(digimon.filter(digimon => digimon.name.toLowerCase() === digimon_name.toLowerCase()));
+        res.json(digimon.find(digimon => digimon.name.toLowerCase() === digimon_name.toLowerCase()));
     } else {
         res.status(400).json(
             {


### PR DESCRIPTION
**Problem**
When searching the Digimon by name, returns an array.

**Solution**
Change filter method to find a method to return a single Digimon object instead of an array